### PR TITLE
Ошибка FileNotFoundException при отсутствии файлов конфигурации в локальной и Roaming папках

### DIFF
--- a/Helper/Utils.cs
+++ b/Helper/Utils.cs
@@ -76,8 +76,9 @@ namespace SiteWatcher
                 if(_currentConfig==null) {
                     if(File.Exists(AppConfig)){
                         _oldConfig = ReadAllText(AppConfig);
-                        _currentConfig = Deserialize<SiteWatcherConfig>(_oldConfig)??new SiteWatcherConfig();
-                    }else{
+                        _currentConfig = Deserialize<SiteWatcherConfig>(_oldConfig) ?? new();
+                    }
+                    else{
                         _currentConfig = new();
                     }
                 }
@@ -130,8 +131,8 @@ namespace SiteWatcher
                     }
                 }
             } else {
-                string dir = Path.GetDirectoryName(filenameRoaming);
-                if(!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+                if (!File.Exists(filenameRoaming))
+                    File.Create(filenameRoaming);
                 return filenameRoaming;
             }
         }
@@ -190,7 +191,6 @@ namespace SiteWatcher
             }
             catch (System.Exception e)
             {
-                Log(e.Message,"error");
                 return default(T);
             }
         }


### PR DESCRIPTION
Ошибка возникает, если конфигурационный файл Watches.json отсутствует в обеих директориях. При попытке сделать File.Move в методе RewriteFile возникало исключение, поэтому файлы необходимо предварительно создавать, если они отсутствуют. Также в методе Deserialize при пустом конфигурационном файле Config.json появлялось переполнение стека из-за перехода в метод Log при неудачной десериализации, так как в функции логирования было повторное рекурсионное обращение к свойству класса.